### PR TITLE
Add multi-screen onboarding walkthrough

### DIFF
--- a/lib/features/onboarding/view/onboarding_page.dart
+++ b/lib/features/onboarding/view/onboarding_page.dart
@@ -1,25 +1,122 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-class OnboardingPage extends StatelessWidget {
+class OnboardingPage extends StatefulWidget {
   const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final _controller = PageController();
+  int _currentPage = 0;
+
+  final _pages = const [
+    {
+      'title': 'Build Healthy Habits',
+      'subtitle':
+          'Set goals, get reminders, and create a routine that sticks.',
+    },
+    {
+      'title': 'Progress That Feels Good',
+      'subtitle':
+          'Notice improvements in your body and mind, one peaceful session at a time.',
+    },
+    {
+      'title': 'Feel Strong, Inside Out',
+      'subtitle':
+          'Unlock your inner power with daily yoga, breathwork, and positive rituals.',
+    },
+  ];
+
+  void _nextOrFinish() {
+    if (_currentPage < _pages.length - 1) {
+      _controller.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    } else {
+      context.go('/login');
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
+      body: SafeArea(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
-              'Welcome to Yoga App',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            Expanded(
+              child: PageView.builder(
+                controller: _controller,
+                itemCount: _pages.length,
+                onPageChanged: (index) => setState(() => _currentPage = index),
+                itemBuilder: (context, index) {
+                  final page = _pages[index];
+                  return Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          page['title']!,
+                          style: const TextStyle(
+                            fontSize: 28,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          page['subtitle']!,
+                          style: const TextStyle(fontSize: 16),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
-            const SizedBox(height: 32),
-            ElevatedButton(
-              onPressed: () => context.go('/login'),
-              child: const Text('Get Started'),
-            )
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(
+                _pages.length,
+                (index) => Container(
+                  margin: const EdgeInsets.all(4),
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: _currentPage == index
+                        ? Colors.blue
+                        : Colors.grey.shade400,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _nextOrFinish,
+                  child: Text(
+                    _currentPage == _pages.length - 1
+                        ? 'Get Started'
+                        : 'Next',
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- implement three-page onboarding walkthrough with page indicators and next/get started button

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891982521c08331868b06bed16f43ae