### PR TITLE
Allow forgot password navigation

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -80,12 +80,17 @@ class App extends StatelessWidget {
                 final loggingIn = loc == '/login';
                 final splash = loc == '/splash';
                 final onboarding = loc == '/onboarding';
+                final forgotPassword = loc == '/forgot-password';
 
                 if (!loggedIn) {
-                  if (loggingIn || splash || onboarding) return null;
+                  if (loggingIn || splash || onboarding || forgotPassword) {
+                    return null;
+                  }
                   return '/login';
                 }
-                if (loggingIn || splash || onboarding) return '/';
+                if (loggingIn || splash || onboarding || forgotPassword) {
+                  return '/';
+                }
                 return null;
               },
             );


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `forgot-password`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b3ac91288331a6799ad4c3839e34