### PR TITLE
Use Java 17 toolchain for Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,12 +11,16 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        // Align the Kotlin compiler with the Java 17 toolchain used by newer
+        // versions of the Android Gradle Plugin.  This avoids `jlink` failures
+        // when dependencies such as `video_player_android` require Java 17
+        // bytecode during compilation.
+        jvmTarget = "17"
     }
 
     defaultConfig {


### PR DESCRIPTION
## Summary
- Target Java 17 for Android compilation and Kotlin JVM to avoid jlink failures when building video_player module

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ce71b4ec83318fd3bec68f8ccc18