### PR TITLE
Use Java 17 toolchain for Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,18 +5,29 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+java {
+    // Use JDK 17 for all Java compilation tasks.
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     namespace = "com.example.saara"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        // Align the Kotlin compiler with the Java 17 toolchain used by newer
+        // versions of the Android Gradle Plugin.  This avoids `jlink` failures
+        // when dependencies such as `video_player_android` require Java 17
+        // bytecode during compilation.
+        jvmTarget = "17"
     }
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,28 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Ensure all modules, including plugins, target Java 17 which is required by
+// newer versions of the Android Gradle Plugin and avoids jlink failures when
+// compiling dependencies such as `video_player_android`.
+subprojects {
+    plugins.withType(JavaPlugin).configureEach {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(17)
+            }
+        }
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions { jvmTarget = "17" }
+    }
+}
+
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## Summary
- Target Java 17 for Android compilation and Kotlin JVM to avoid jlink failures when building video_player module
- Configure Java 17 toolchain across all subprojects so plugins compile with the same JDK

## Testing
- `flutter test` *(fails: command not found)*
- `cd android && ./gradlew -version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891ce71b4ec83318fd3bec68f8ccc18