### PR TITLE
Fix web video player not implemented error

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   go_router: ^14.0.0
   dio: ^5.4.0
   video_player: ^2.9.0
+  video_player_web: ^2.0.17
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `video_player_web` plugin to enable playback on web

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892dc3684bc8331ad156178cc0ba03c