### PR TITLE
Ensure video player plugin is initialized

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'app.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   runApp(const App());
 }
 


### PR DESCRIPTION
## Summary
- call `WidgetsFlutterBinding.ensureInitialized()` before `runApp` so the video_player plugin can register correctly

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892e63084688331ae07872adc719968