### PR TITLE
Add class detail screen and link class cards

### DIFF
--- a/lib/features/home/view/class_detail_page.dart
+++ b/lib/features/home/view/class_detail_page.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:saara/features/video/view/video_page.dart';
+
+class ClassDetailPage extends StatelessWidget {
+  final String title;
+  final String image;
+  final int videoCount;
+
+  const ClassDetailPage({
+    super.key,
+    required this.title,
+    required this.image,
+    required this.videoCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final videos = List.generate(videoCount, (index) => 'Video ${index + 1}');
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Image.asset(
+              image,
+              height: 200,
+              width: double.infinity,
+              fit: BoxFit.cover,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () {},
+            child: const Text('Start Watching'),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'About this class',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'This is a placeholder description for the class.',
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '${videos.length} items',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              IconButton(
+                icon: const Icon(Icons.filter_list),
+                onPressed: () {},
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...videos.map(
+            (v) => ListTile(
+              leading: const Icon(Icons.play_circle_outline),
+              title: Text(v),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const VideoPage(),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
+import 'class_detail_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -348,35 +349,51 @@ class _ClassCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(12),
-      child: Stack(
-        children: [
-          Image.asset(image, height: 160, width: 240, fit: BoxFit.cover),
-          Positioned(
-            bottom: 0,
-            left: 0,
-            right: 0,
-            child: Container(
-              color: const Color(0xFFA78BFA).withOpacity(0.9),
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      title,
-                      style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold),
-                    ),
-                  ),
-                  Text(subtitle,
-                      style: const TextStyle(color: Colors.white70)),
-                ],
-              ),
+    final videoCount =
+        int.tryParse(RegExp(r'\d+').firstMatch(subtitle)?.group(0) ?? '') ?? 0;
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => ClassDetailPage(
+              title: title,
+              image: image,
+              videoCount: videoCount,
             ),
           ),
-        ],
+        );
+      },
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: Stack(
+          children: [
+            Image.asset(image, height: 160, width: 240, fit: BoxFit.cover),
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                color: const Color(0xFFA78BFA).withOpacity(0.9),
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    Text(subtitle,
+                        style: const TextStyle(color: Colors.white70)),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add ClassDetailPage with image, start button, description, filter and video list
- open the detail page from Saara class cards

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68931ab4ca088331912c789f47e50a5c