### PR TITLE
Add video playback screen and connect Start Watching

### DIFF
--- a/lib/features/home/view/class_detail_page.dart
+++ b/lib/features/home/view/class_detail_page.dart
@@ -89,7 +89,12 @@ class ClassDetailPage extends StatelessWidget {
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton.icon(
-                      onPressed: () {},
+                      onPressed: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const VideoPage(),
+                        ),
+                      ),
                       icon: const Icon(Icons.play_arrow),
                       label: const Padding(
                         padding: EdgeInsets.symmetric(vertical: 14),

--- a/lib/features/video/view/video_page.dart
+++ b/lib/features/video/view/video_page.dart
@@ -1,14 +1,76 @@
 import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
 
-class VideoPage extends StatelessWidget {
+class VideoPage extends StatefulWidget {
   const VideoPage({super.key});
 
   @override
+  State<VideoPage> createState() => _VideoPageState();
+}
+
+class _VideoPageState extends State<VideoPage> {
+  late VideoPlayerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = VideoPlayerController.networkUrl(
+      Uri.parse('https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'),
+    )..initialize().then((_) {
+        setState(() {});
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _togglePlay() {
+    setState(() {
+      if (_controller.value.isPlaying) {
+        _controller.pause();
+      } else {
+        _controller.play();
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return  Scaffold(
-      appBar: AppBar(title: Text('Video')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Video')),
       body: Center(
-        child: Text('Yoga video placeholder'),
+        child: _controller.value.isInitialized
+            ? Stack(
+                alignment: Alignment.center,
+                children: [
+                  AspectRatio(
+                    aspectRatio: _controller.value.aspectRatio,
+                    child: VideoPlayer(_controller),
+                  ),
+                  GestureDetector(
+                    onTap: _togglePlay,
+                    child: Container(
+                      width: 64,
+                      height: 64,
+                      decoration: BoxDecoration(
+                        color: Colors.black45,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        _controller.value.isPlaying
+                            ? Icons.pause
+                            : Icons.play_arrow,
+                        color: Colors.white,
+                        size: 40,
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            : const CircularProgressIndicator(),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- navigate "Start Watching" to video playback
- implement dummy video screen with play/pause controls

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68933005e7748331949c2ef53308dab3