### PR TITLE
Hook up classes tab and program details

### DIFF
--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -22,7 +22,7 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     final pages = [
       const _ExploreView(),
-      const Center(child: Text('Classes Page')),
+      const ClassesPage(),
       const Center(child: Text('Search Page')),
       const Center(child: Text('Settings Page')),
     ];
@@ -40,37 +40,39 @@ class _HomePageState extends State<HomePage> {
           ListTile(leading: Icon(Icons.person), title: Text('Profile')),
         ]),
       ),
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        elevation: 0,
-        centerTitle: true,
-        title: Text(titles[_currentIndex],
-            style: const TextStyle(color: Colors.black)),
-        leading: Builder(
-          builder: (ctx) => IconButton(
-            icon: const Icon(Icons.menu, color: Colors.black87),
-            onPressed: () => Scaffold.of(ctx).openDrawer(),
-          ),
-        ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: GestureDetector(
-              onTap: () {
-                Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (_) => const NotificationPage()));
-              },
-              child: CircleAvatar(
-                backgroundColor: primaryPurple.withOpacity(0.1),
-                child: const Icon(Icons.notifications_none,
-                    color: primaryPurple),
+      appBar: _currentIndex == 1
+          ? null
+          : AppBar(
+              backgroundColor: Colors.white,
+              elevation: 0,
+              centerTitle: true,
+              title: Text(titles[_currentIndex],
+                  style: const TextStyle(color: Colors.black)),
+              leading: Builder(
+                builder: (ctx) => IconButton(
+                  icon: const Icon(Icons.menu, color: Colors.black87),
+                  onPressed: () => Scaffold.of(ctx).openDrawer(),
+                ),
               ),
+              actions: [
+                Padding(
+                  padding: const EdgeInsets.only(right: 16),
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const NotificationPage()));
+                    },
+                    child: CircleAvatar(
+                      backgroundColor: primaryPurple.withOpacity(0.1),
+                      child: const Icon(Icons.notifications_none,
+                          color: primaryPurple),
+                    ),
+                  ),
+                )
+              ],
             ),
-          )
-        ],
-      ),
 
       body: IndexedStack(index: _currentIndex, children: pages),
 

--- a/lib/features/home/view/programs_page.dart
+++ b/lib/features/home/view/programs_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../cubit/home_cubit.dart';
+import 'class_detail_page.dart';
 
 class ProgramsPage extends StatelessWidget {
   const ProgramsPage({super.key});
@@ -14,10 +15,26 @@ class ProgramsPage extends StatelessWidget {
         itemCount: programs.length,
         itemBuilder: (context, index) {
           final item = programs[index];
+          final videoCount = int.tryParse(
+                RegExp(r'\\d+').firstMatch(item.subtitle)?.group(0) ?? '') ??
+              0;
           return ListTile(
             leading: Image.asset(item.image, width: 60, fit: BoxFit.cover),
             title: Text(item.title),
             subtitle: Text(item.subtitle),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ClassDetailPage(
+                    title: item.title,
+                    image: item.image,
+                    videoCount: videoCount,
+                    description: '',
+                  ),
+                ),
+              );
+            },
           );
         },
       ),


### PR DESCRIPTION
## Summary
- Connect bottom navigation "Classes" tab to the real classes list
- Hide outer app bar on classes tab to avoid duplicated bars
- Allow program list items to open class details

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893471555048331bd7c9499b3227f73