### PR TITLE
Integrate Firebase authentication with Google and Facebook

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
+    id "com.google.gms.google-services"
 }
 
 java {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,6 +20,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.1.0" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.google.gms.google-services" version "4.3.15" apply false
 }
 
 include ":app"

--- a/lib/features/auth/bloc/auth_bloc.dart
+++ b/lib/features/auth/bloc/auth_bloc.dart
@@ -18,6 +18,10 @@ class AuthLoginRequested extends AuthEvent {
   final String password;
 }
 
+class AuthGoogleLoginRequested extends AuthEvent {}
+
+class AuthFacebookLoginRequested extends AuthEvent {}
+
 class AuthLogoutRequested extends AuthEvent {}
 
 enum AuthStatus { authenticated, unauthenticated }
@@ -39,6 +43,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   AuthBloc(this._repository) : super(const AuthState.unauthenticated()) {
     on<AuthUserChanged>(_onUserChanged);
     on<AuthLoginRequested>(_onLoginRequested);
+    on<AuthGoogleLoginRequested>(_onGoogleLoginRequested);
+    on<AuthFacebookLoginRequested>(_onFacebookLoginRequested);
     on<AuthLogoutRequested>(_onLogoutRequested);
     _subscription = _repository.stream.listen((user) {
       add(AuthUserChanged(user));
@@ -61,6 +67,16 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   Future<void> _onLoginRequested(
       AuthLoginRequested event, Emitter<AuthState> emit) async {
     await _repository.logIn(email: event.email, password: event.password);
+  }
+
+  Future<void> _onGoogleLoginRequested(
+      AuthGoogleLoginRequested event, Emitter<AuthState> emit) async {
+    await _repository.logInWithGoogle();
+  }
+
+  Future<void> _onFacebookLoginRequested(
+      AuthFacebookLoginRequested event, Emitter<AuthState> emit) async {
+    await _repository.logInWithFacebook();
   }
 
   Future<void> _onLogoutRequested(

--- a/lib/features/auth/repository/auth_repository.dart
+++ b/lib/features/auth/repository/auth_repository.dart
@@ -1,31 +1,66 @@
-import 'dart:async';
-
-import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 
 import '../models/user.dart';
 
 class AuthRepository {
-  AuthRepository({Dio? dio}) : _dio = dio ?? Dio();
+  AuthRepository({
+    fb.FirebaseAuth? firebaseAuth,
+    GoogleSignIn? googleSignIn,
+    FacebookAuth? facebookAuth,
+  })  : _firebaseAuth = firebaseAuth ?? fb.FirebaseAuth.instance,
+        _googleSignIn = googleSignIn ?? GoogleSignIn(),
+        _facebookAuth = facebookAuth ?? FacebookAuth.instance;
 
-  final Dio _dio;
-  final _controller = StreamController<User?>.broadcast();
-  User? _currentUser;
+  final fb.FirebaseAuth _firebaseAuth;
+  final GoogleSignIn _googleSignIn;
+  final FacebookAuth _facebookAuth;
 
-  Stream<User?> get stream => _controller.stream;
-  User? get currentUser => _currentUser;
+  Stream<User?> get stream =>
+      _firebaseAuth.authStateChanges().map(_userFromFirebase);
+
+  User? get currentUser => _userFromFirebase(_firebaseAuth.currentUser);
+
+  User? _userFromFirebase(fb.User? user) {
+    if (user == null) return null;
+    return User(email: user.email ?? '', isMember: true);
+  }
 
   Future<void> logIn({required String email, required String password}) async {
-    // Placeholder for API call using Dio
-    await Future<void>.delayed(const Duration(milliseconds: 300));
-    _currentUser = User(email: email, isMember: true);
-    _controller.add(_currentUser);
+    await _firebaseAuth.signInWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+  }
+
+  Future<void> logInWithGoogle() async {
+    final googleUser = await _googleSignIn.signIn();
+    if (googleUser == null) return;
+    final googleAuth = await googleUser.authentication;
+    final credential = fb.GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    await _firebaseAuth.signInWithCredential(credential);
+  }
+
+  Future<void> logInWithFacebook() async {
+    final result = await _facebookAuth.login();
+    if (result.status != LoginStatus.success) return;
+    final credential = fb.FacebookAuthProvider.credential(
+      result.accessToken!.token,
+    );
+    await _firebaseAuth.signInWithCredential(credential);
   }
 
   Future<void> logOut() async {
-    _currentUser = null;
-    _controller.add(null);
+    await Future.wait([
+      _firebaseAuth.signOut(),
+      _googleSignIn.signOut(),
+      _facebookAuth.logOut(),
+    ]);
   }
 
-  void dispose() => _controller.close();
+  void dispose() {}
 }
-

--- a/lib/features/login/view/login_page.dart
+++ b/lib/features/login/view/login_page.dart
@@ -129,9 +129,17 @@ class _LoginPageState extends State<LoginPage> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  _socialButton(icon: Icons.facebook, onTap: () {}),
+                  _socialButton(
+                      icon: Icons.facebook,
+                      onTap: () => context
+                          .read<AuthBloc>()
+                          .add(AuthFacebookLoginRequested())),
                   const SizedBox(width: 24),
-                  _socialButton(icon: Icons.g_mobiledata, onTap: () {}),
+                  _socialButton(
+                      icon: Icons.g_mobiledata,
+                      onTap: () => context
+                          .read<AuthBloc>()
+                          .add(AuthGoogleLoginRequested())),
                   const SizedBox(width: 24),
                   _socialButton(icon: Icons.apple, onTap: () {}),
                 ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
 
 import 'app.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   runApp(const App());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,10 @@ dependencies:
   video_player: ^2.9.5
   video_player_web: ^2.0.17
   equatable: ^2.0.5
+  firebase_core: ^2.24.2
+  firebase_auth: ^4.16.0
+  google_sign_in: ^6.1.5
+  flutter_facebook_auth: ^6.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Firebase core/auth and social sign-in dependencies
- initialize Firebase on app start
- implement Firebase-backed auth repository with Google and Facebook login
- wire up bloc and login page for social sign-in
- configure Android build scripts for Firebase

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942f9905788331a659a889ca029a2c