### PR TITLE
Add settings page with navigation drawer

### DIFF
--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -6,6 +6,7 @@ import '../cubit/home_cubit.dart';
 import 'classes_page.dart';
 import 'programs_page.dart';
 import '../../notifications/view/notification_page.dart';
+import '../../settings/view/settings_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -24,7 +25,7 @@ class _HomePageState extends State<HomePage> {
       const _ExploreView(),
       const ClassesPage(),
       const Center(child: Text('Search Page')),
-      const Center(child: Text('Settings Page')),
+      const SettingsPage(),
     ];
     final titles = ['Explore', 'Classes', 'Search', 'Settings'];
 
@@ -32,13 +33,48 @@ class _HomePageState extends State<HomePage> {
       create: (_) => HomeCubit(),
       child: Scaffold(
       drawer: Drawer(
-        child: ListView(padding: EdgeInsets.zero, children: const [
-          DrawerHeader(
-            decoration: BoxDecoration(color: primaryPurple),
-            child: Text('Menu', style: TextStyle(color: Colors.white)),
-          ),
-          ListTile(leading: Icon(Icons.person), title: Text('Profile')),
-        ]),
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(color: primaryPurple),
+              child: Text('Menu', style: TextStyle(color: Colors.white)),
+            ),
+            ListTile(
+              leading: const Icon(Icons.explore_outlined),
+              title: const Text('Explore'),
+              onTap: () {
+                setState(() => _currentIndex = 0);
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.self_improvement_outlined),
+              title: const Text('Classes'),
+              onTap: () {
+                setState(() => _currentIndex = 1);
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.search_outlined),
+              title: const Text('Search'),
+              onTap: () {
+                setState(() => _currentIndex = 2);
+                Navigator.pop(context);
+              },
+            ),
+            const Divider(),
+            ListTile(
+              leading: const Icon(Icons.settings_outlined),
+              title: const Text('Settings'),
+              onTap: () {
+                setState(() => _currentIndex = 3);
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        ),
       ),
       appBar: _currentIndex == 1
           ? null

--- a/lib/features/settings/view/settings_page.dart
+++ b/lib/features/settings/view/settings_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  bool _notificationsEnabled = true;
+  bool _darkMode = false;
+
+  @override
+  Widget build(BuildContext context) {
+    const primaryPurple = Color(0xFFA78BFA);
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        SwitchListTile(
+          value: _notificationsEnabled,
+          activeColor: primaryPurple,
+          title: const Text('Enable notifications'),
+          onChanged: (value) {
+            setState(() => _notificationsEnabled = value);
+          },
+        ),
+        SwitchListTile(
+          value: _darkMode,
+          activeColor: primaryPurple,
+          title: const Text('Dark mode'),
+          onChanged: (value) {
+            setState(() => _darkMode = value);
+          },
+        ),
+      ],
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Implement a stateful SettingsPage with notification and dark mode toggles
- Integrate SettingsPage into HomePage navigation and enhance drawer with quick links

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944eae96c88331936dce81b7ecc307