### PR TITLE
feat: add dark mode support

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,6 +12,7 @@ import 'features/video/view/video_page.dart';
 import 'features/onboarding/view/onboarding_page.dart';
 import 'features/splash/view/splash_page.dart';
 import 'features/forgot_password/view/forgot_password_page.dart';
+import 'theme/cubit/theme_cubit.dart';
 
 /// A ChangeNotifier that listens to a Stream and notifies listeners on each event.
 /// Replacement for the removed GoRouterRefreshStream helper.
@@ -41,8 +42,11 @@ class App extends StatelessWidget {
 
     return RepositoryProvider.value(
       value: authRepository,
-      child: BlocProvider(
-        create: (_) => AuthBloc(authRepository),
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider(create: (_) => AuthBloc(authRepository)),
+          BlocProvider(create: (_) => ThemeCubit()),
+        ],
         child: Builder(
           builder: (context) {
             final authBloc = context.read<AuthBloc>();
@@ -97,6 +101,8 @@ class App extends StatelessWidget {
               },
             );
 
+            final themeMode = context.watch<ThemeCubit>().state;
+
             return BlocListener<AuthBloc, AuthState>(
               listener: (context, state) {
                 if (state.status == AuthStatus.authenticated) {
@@ -116,6 +122,18 @@ class App extends StatelessWidget {
                 debugShowCheckedModeBanner: false,
                 routerConfig: router,
                 scaffoldMessengerKey: _messengerKey,
+                theme: ThemeData(
+                  colorScheme: ColorScheme.fromSeed(
+                    seedColor: const Color(0xFFA78BFA),
+                  ),
+                ),
+                darkTheme: ThemeData(
+                  colorScheme: ColorScheme.fromSeed(
+                    seedColor: const Color(0xFFA78BFA),
+                    brightness: Brightness.dark,
+                  ),
+                ),
+                themeMode: themeMode,
               ),
             );
           },

--- a/lib/features/forgot_password/view/forgot_password_page.dart
+++ b/lib/features/forgot_password/view/forgot_password_page.dart
@@ -13,18 +13,15 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
 
   @override
   Widget build(BuildContext context) {
-    const bgColor = Color(0xFFFCF9F5);
     const primaryPurple = Color(0xFFA78BFA);
 
     return Scaffold(
-      backgroundColor: bgColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
         centerTitle: true,
-        title: const Text('Forgot Password',
-            style: TextStyle(color: Colors.black)),
-        iconTheme: const IconThemeData(color: Colors.black),
+        title: const Text('Forgot Password'),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -41,12 +38,14 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
             Text(
               'Enter your email and we\'ll send you a link to reset your password.',
               textAlign: TextAlign.center,
-              style: TextStyle(color: Colors.grey.shade700),
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
             ),
             const SizedBox(height: 24),
             Container(
               decoration: BoxDecoration(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.surface,
                 boxShadow: const [
                   BoxShadow(
                     color: Colors.black12,
@@ -61,8 +60,10 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
                 keyboardType: TextInputType.emailAddress,
                 decoration: InputDecoration(
                   hintText: 'Email',
-                  prefixIcon: Icon(Icons.email_outlined,
-                      color: Colors.grey.shade600),
+                  prefixIcon: Icon(
+                    Icons.email_outlined,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                   border: OutlineInputBorder(
                     borderSide: BorderSide.none,
                     borderRadius: BorderRadius.circular(12),

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -32,105 +32,113 @@ class _HomePageState extends State<HomePage> {
     return BlocProvider(
       create: (_) => HomeCubit(),
       child: Scaffold(
-      drawer: Drawer(
-        child: ListView(
-          padding: EdgeInsets.zero,
-          children: [
-            const DrawerHeader(
-              decoration: BoxDecoration(color: primaryPurple),
-              child: Text('Menu', style: TextStyle(color: Colors.white)),
-            ),
-            ListTile(
-              leading: const Icon(Icons.explore_outlined),
-              title: const Text('Explore'),
-              onTap: () {
-                setState(() => _currentIndex = 0);
-                Navigator.pop(context);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.self_improvement_outlined),
-              title: const Text('Classes'),
-              onTap: () {
-                setState(() => _currentIndex = 1);
-                Navigator.pop(context);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.search_outlined),
-              title: const Text('Search'),
-              onTap: () {
-                setState(() => _currentIndex = 2);
-                Navigator.pop(context);
-              },
-            ),
-            const Divider(),
-            ListTile(
-              leading: const Icon(Icons.settings_outlined),
-              title: const Text('Settings'),
-              onTap: () {
-                setState(() => _currentIndex = 3);
-                Navigator.pop(context);
-              },
-            ),
+        drawer: Drawer(
+          child: ListView(
+            padding: EdgeInsets.zero,
+            children: [
+              const DrawerHeader(
+                decoration: BoxDecoration(color: primaryPurple),
+                child: Text('Menu', style: TextStyle(color: Colors.white)),
+              ),
+              ListTile(
+                leading: const Icon(Icons.explore_outlined),
+                title: const Text('Explore'),
+                onTap: () {
+                  setState(() => _currentIndex = 0);
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.self_improvement_outlined),
+                title: const Text('Classes'),
+                onTap: () {
+                  setState(() => _currentIndex = 1);
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.search_outlined),
+                title: const Text('Search'),
+                onTap: () {
+                  setState(() => _currentIndex = 2);
+                  Navigator.pop(context);
+                },
+              ),
+              const Divider(),
+              ListTile(
+                leading: const Icon(Icons.settings_outlined),
+                title: const Text('Settings'),
+                onTap: () {
+                  setState(() => _currentIndex = 3);
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
+        ),
+        appBar: _currentIndex == 1
+            ? null
+            : AppBar(
+                backgroundColor: Theme.of(context).colorScheme.surface,
+                elevation: 0,
+                centerTitle: true,
+                title: Text(
+                  titles[_currentIndex],
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+                leading: Builder(
+                  builder: (ctx) => IconButton(
+                    icon: Icon(
+                      Icons.menu,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                    onPressed: () => Scaffold.of(ctx).openDrawer(),
+                  ),
+                ),
+                actions: [
+                  Padding(
+                    padding: const EdgeInsets.only(right: 16),
+                    child: GestureDetector(
+                      onTap: () {
+                        Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (_) => const NotificationPage()));
+                      },
+                      child: CircleAvatar(
+                        backgroundColor: primaryPurple.withOpacity(0.1),
+                        child: const Icon(
+                          Icons.notifications_none,
+                          color: primaryPurple,
+                        ),
+                      ),
+                    ),
+                  )
+                ],
+              ),
+        body: IndexedStack(index: _currentIndex, children: pages),
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: _currentIndex,
+          selectedItemColor: primaryPurple,
+          unselectedItemColor:
+              Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+          showUnselectedLabels: true,
+          onTap: (i) => setState(() => _currentIndex = i),
+          items: const [
+            BottomNavigationBarItem(
+                icon: Icon(Icons.explore_outlined), label: 'Explore'),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.self_improvement_outlined),
+                label: 'Classes'),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.search_outlined), label: 'Search'),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.settings_outlined), label: 'Settings'),
           ],
         ),
-      ),
-      appBar: _currentIndex == 1
-          ? null
-          : AppBar(
-              backgroundColor: Colors.white,
-              elevation: 0,
-              centerTitle: true,
-              title: Text(titles[_currentIndex],
-                  style: const TextStyle(color: Colors.black)),
-              leading: Builder(
-                builder: (ctx) => IconButton(
-                  icon: const Icon(Icons.menu, color: Colors.black87),
-                  onPressed: () => Scaffold.of(ctx).openDrawer(),
-                ),
-              ),
-              actions: [
-                Padding(
-                  padding: const EdgeInsets.only(right: 16),
-                  child: GestureDetector(
-                    onTap: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (_) => const NotificationPage()));
-                    },
-                    child: CircleAvatar(
-                      backgroundColor: primaryPurple.withOpacity(0.1),
-                      child: const Icon(Icons.notifications_none,
-                          color: primaryPurple),
-                    ),
-                  ),
-                )
-              ],
-            ),
-
-      body: IndexedStack(index: _currentIndex, children: pages),
-
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        selectedItemColor: primaryPurple,
-        unselectedItemColor: Colors.grey.shade400,
-        showUnselectedLabels: true,
-        onTap: (i) => setState(() => _currentIndex = i),
-        items: const [
-          BottomNavigationBarItem(
-              icon: Icon(Icons.explore_outlined), label: 'Explore'),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.self_improvement_outlined),
-              label: 'Classes'),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.search_outlined), label: 'Search'),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.settings_outlined), label: 'Settings'),
-        ],
-      ),
-    ));
+      ));
   }
 }
 

--- a/lib/features/settings/view/settings_page.dart
+++ b/lib/features/settings/view/settings_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../theme/cubit/theme_cubit.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -9,7 +12,6 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   bool _notificationsEnabled = true;
-  bool _darkMode = false;
 
   @override
   Widget build(BuildContext context) {
@@ -27,11 +29,11 @@ class _SettingsPageState extends State<SettingsPage> {
           },
         ),
         SwitchListTile(
-          value: _darkMode,
+          value: context.watch<ThemeCubit>().state == ThemeMode.dark,
           activeColor: primaryPurple,
           title: const Text('Dark mode'),
           onChanged: (value) {
-            setState(() => _darkMode = value);
+            context.read<ThemeCubit>().toggle(value);
           },
         ),
       ],

--- a/lib/theme/cubit/theme_cubit.dart
+++ b/lib/theme/cubit/theme_cubit.dart
@@ -1,0 +1,10 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+
+/// Controls the application's [ThemeMode].
+class ThemeCubit extends Cubit<ThemeMode> {
+  ThemeCubit() : super(ThemeMode.light);
+
+  /// Switch between light and dark themes.
+  void toggle(bool isDark) => emit(isDark ? ThemeMode.dark : ThemeMode.light);
+}


### PR DESCRIPTION
## Summary
- add ThemeCubit to manage ThemeMode
- wire dark mode switch in settings page
- replace hard-coded colors with theme colors and configure MaterialApp themes

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68944ffa451c833187bd825b3f58a9ac