### PR TITLE
feat: add custom gradient app bar

### DIFF
--- a/lib/features/forgot_password/view/forgot_password_page.dart
+++ b/lib/features/forgot_password/view/forgot_password_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:saara/widgets/custom_app_bar.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
   const ForgotPasswordPage({super.key});
@@ -17,12 +18,7 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        centerTitle: true,
-        title: const Text('Forgot Password'),
-      ),
+      appBar: const CustomAppBar(title: 'Forgot Password'),
       body: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Column(

--- a/lib/features/home/view/classes_page.dart
+++ b/lib/features/home/view/classes_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:saara/widgets/custom_app_bar.dart';
 import '../cubit/home_cubit.dart';
 import 'class_detail_page.dart';
 
@@ -10,7 +11,7 @@ class ClassesPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final classes = context.watch<HomeCubit>().state.classes;
     return Scaffold(
-      appBar: AppBar(title: const Text('Classes')),
+      appBar: const CustomAppBar(title: 'Classes'),
       body: ListView.builder(
         itemCount: classes.length,
         itemBuilder: (context, index) {

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:video_player/video_player.dart';
+import 'package:saara/widgets/custom_app_bar.dart';
 import 'class_detail_page.dart';
 import '../cubit/home_cubit.dart';
 import 'classes_page.dart';
@@ -155,22 +156,11 @@ class _HomePageState extends State<HomePage> {
         ),
         appBar: _currentIndex == 1
             ? null
-            : AppBar(
-                backgroundColor: Theme.of(context).colorScheme.surface,
-                elevation: 0,
-                centerTitle: true,
-                title: Text(
-                  titles[_currentIndex],
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                ),
+            : CustomAppBar(
+                title: titles[_currentIndex],
                 leading: Builder(
                   builder: (ctx) => IconButton(
-                    icon: Icon(
-                      Icons.menu,
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
+                    icon: const Icon(Icons.menu),
                     onPressed: () => Scaffold.of(ctx).openDrawer(),
                   ),
                 ),
@@ -185,10 +175,10 @@ class _HomePageState extends State<HomePage> {
                                 builder: (_) => const NotificationPage()));
                       },
                       child: CircleAvatar(
-                        backgroundColor: primaryPurple.withOpacity(0.1),
+                        backgroundColor: Colors.white.withOpacity(0.1),
                         child: const Icon(
                           Icons.notifications_none,
-                          color: primaryPurple,
+                          color: Colors.white,
                         ),
                       ),
                     ),

--- a/lib/features/home/view/programs_page.dart
+++ b/lib/features/home/view/programs_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:saara/widgets/custom_app_bar.dart';
 import '../cubit/home_cubit.dart';
 import 'class_detail_page.dart';
 
@@ -10,7 +11,7 @@ class ProgramsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final programs = context.watch<HomeCubit>().state.programs;
     return Scaffold(
-      appBar: AppBar(title: const Text('Programs')),
+      appBar: const CustomAppBar(title: 'Programs'),
       body: ListView.builder(
         itemCount: programs.length,
         itemBuilder: (context, index) {

--- a/lib/features/notifications/view/notification_page.dart
+++ b/lib/features/notifications/view/notification_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:saara/widgets/custom_app_bar.dart';
 import '../cubit/notification_cubit.dart';
 
 class NotificationPage extends StatelessWidget {
@@ -10,7 +11,7 @@ class NotificationPage extends StatelessWidget {
     return BlocProvider(
       create: (_) => NotificationCubit(),
       child: Scaffold(
-        appBar: AppBar(title: const Text('Notifications')),
+        appBar: const CustomAppBar(title: 'Notifications'),
         body: BlocBuilder<NotificationCubit, List<String>>(
           builder: (context, notifications) {
             if (notifications.isEmpty) {

--- a/lib/widgets/custom_app_bar.dart
+++ b/lib/widgets/custom_app_bar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final Widget? leading;
+  final List<Widget>? actions;
+  final double height;
+
+  const CustomAppBar({
+    super.key,
+    required this.title,
+    this.leading,
+    this.actions,
+    this.height = 100,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      elevation: 0,
+      centerTitle: true,
+      backgroundColor: Colors.transparent,
+      foregroundColor: Colors.white,
+      toolbarHeight: height,
+      leading: leading,
+      actions: actions,
+      title: Text(
+        title,
+        style: const TextStyle(
+          fontSize: 24,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      flexibleSpace: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFA78BFA), Color(0xFF6366F1)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          bottom: Radius.circular(24),
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(height);
+}


### PR DESCRIPTION
## Summary
- add reusable custom app bar with gradient background and rounded bottom
- apply new app bar to home, notifications, programs, classes and forgot-password pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689471ed64a083318f5be8bc6b3704d2