### PR TITLE
refactor: use go_router for navigation

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,6 +12,12 @@ import 'features/video/view/video_page.dart';
 import 'features/onboarding/view/onboarding_page.dart';
 import 'features/splash/view/splash_page.dart';
 import 'features/forgot_password/view/forgot_password_page.dart';
+import 'features/notifications/view/notification_page.dart';
+import 'features/home/view/classes_page.dart';
+import 'features/home/view/programs_page.dart';
+import 'features/home/view/class_detail_page.dart';
+import 'features/home/cubit/home_cubit.dart';
+import 'package:video_player/video_player.dart';
 import 'theme/cubit/theme_cubit.dart';
 
 /// A ChangeNotifier that listens to a Stream and notifies listeners on each event.
@@ -77,6 +83,59 @@ class App extends StatelessWidget {
                 GoRoute(
                   path: '/video',
                   builder: (context, state) => const VideoPage(),
+                ),
+                GoRoute(
+                  path: '/video/fullscreen',
+                  builder: (context, state) {
+                    final controller = state.extra as VideoPlayerController;
+                    return FullScreenVideo(controller: controller);
+                  },
+                ),
+                GoRoute(
+                  path: '/notifications',
+                  builder: (context, state) => const NotificationPage(),
+                ),
+                GoRoute(
+                  path: '/classes',
+                  builder: (context, state) {
+                    final cubit = state.extra as HomeCubit?;
+                    return cubit != null
+                        ? BlocProvider.value(
+                            value: cubit,
+                            child: const ClassesPage(),
+                          )
+                        : BlocProvider(
+                            create: (_) => HomeCubit(),
+                            child: const ClassesPage(),
+                          );
+                  },
+                ),
+                GoRoute(
+                  path: '/programs',
+                  builder: (context, state) {
+                    final cubit = state.extra as HomeCubit?;
+                    return cubit != null
+                        ? BlocProvider.value(
+                            value: cubit,
+                            child: const ProgramsPage(),
+                          )
+                        : BlocProvider(
+                            create: (_) => HomeCubit(),
+                            child: const ProgramsPage(),
+                          );
+                  },
+                ),
+                GoRoute(
+                  path: '/class-detail',
+                  builder: (context, state) {
+                    final data = state.extra as Map<String, dynamic>;
+                    return ClassDetailPage(
+                      title: data['title'] as String,
+                      image: data['image'] as String,
+                      videoCount: data['videoCount'] as int,
+                      description: data['description'] as String,
+                    );
+                  },
                 ),
               ],
               redirect: (context, state) {

--- a/lib/features/home/view/class_detail_page.dart
+++ b/lib/features/home/view/class_detail_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:saara/features/video/view/video_page.dart';
+import 'package:go_router/go_router.dart';
 
 /// A detailed page for a class, matching the design shown: large header image
 /// with overlay buttons, a bold title, a prominent "Start Watching" button,
@@ -45,7 +45,7 @@ class ClassDetailPage extends StatelessWidget {
             elevation: 0,
             leading: IconButton(
               icon: const Icon(Icons.arrow_back_ios),
-              onPressed: () => Navigator.pop(context),
+              onPressed: () => context.pop(),
             ),
             actions: [
               IconButton(
@@ -89,12 +89,7 @@ class ClassDetailPage extends StatelessWidget {
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton.icon(
-                      onPressed: () => Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => const VideoPage(),
-                        ),
-                      ),
+                      onPressed: () => context.push('/video'),
                       icon: const Icon(Icons.play_arrow),
                       label: const Padding(
                         padding: EdgeInsets.symmetric(vertical: 14),
@@ -168,12 +163,7 @@ class ClassDetailPage extends StatelessWidget {
                   child: InkWell(
                     onTap: video.locked
                         ? null
-                        : () => Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const VideoPage(),
-                      ),
-                    ),
+                        : () => context.push('/video'),
                     child: Row(
                       children: [
                         // Thumbnail with lock and duration overlays

--- a/lib/features/home/view/classes_page.dart
+++ b/lib/features/home/view/classes_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:saara/widgets/custom_app_bar.dart';
 import '../cubit/home_cubit.dart';
-import 'class_detail_page.dart';
 
 class ClassesPage extends StatelessWidget {
   const ClassesPage({super.key});
@@ -21,19 +21,12 @@ class ClassesPage extends StatelessWidget {
             leading: Image.asset(item.image, width: 60, fit: BoxFit.cover),
             title: Text(item.title),
             subtitle: Text(item.subtitle),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => ClassDetailPage(
-                    title: item.title,
-                    image: item.image,
-                    videoCount: videoCount,
-                    description: '',
-                  ),
-                ),
-              );
-            },
+            onTap: () => context.push('/class-detail', extra: {
+              'title': item.title,
+              'image': item.image,
+              'videoCount': videoCount,
+              'description': '',
+            }),
           );
         },
       ),

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -2,13 +2,12 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:video_player/video_player.dart';
 import 'package:saara/widgets/custom_app_bar.dart';
-import 'class_detail_page.dart';
 import '../cubit/home_cubit.dart';
 import 'classes_page.dart';
 import 'programs_page.dart';
-import '../../notifications/view/notification_page.dart';
 import '../../settings/view/settings_page.dart';
 import '../../search/view/search_page.dart';
 
@@ -123,7 +122,7 @@ class _HomePageState extends State<HomePage> {
                 title: const Text('Explore'),
                 onTap: () {
                   setState(() => _currentIndex = 0);
-                  Navigator.pop(context);
+                  context.pop();
                 },
               ),
               ListTile(
@@ -131,7 +130,7 @@ class _HomePageState extends State<HomePage> {
                 title: const Text('Classes'),
                 onTap: () {
                   setState(() => _currentIndex = 1);
-                  Navigator.pop(context);
+                  context.pop();
                 },
               ),
               ListTile(
@@ -139,7 +138,7 @@ class _HomePageState extends State<HomePage> {
                 title: const Text('Search'),
                 onTap: () {
                   setState(() => _currentIndex = 2);
-                  Navigator.pop(context);
+                  context.pop();
                 },
               ),
               const Divider(),
@@ -148,7 +147,7 @@ class _HomePageState extends State<HomePage> {
                 title: const Text('Settings'),
                 onTap: () {
                   setState(() => _currentIndex = 3);
-                  Navigator.pop(context);
+                  context.pop();
                 },
               ),
             ],
@@ -168,12 +167,7 @@ class _HomePageState extends State<HomePage> {
                   Padding(
                     padding: const EdgeInsets.only(right: 16),
                     child: GestureDetector(
-                      onTap: () {
-                        Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (_) => const NotificationPage()));
-                      },
+                      onTap: () => context.push('/notifications'),
                       child: CircleAvatar(
                         backgroundColor: Colors.white.withOpacity(0.1),
                         child: const Icon(
@@ -317,17 +311,10 @@ class _ExploreViewState extends State<_ExploreView> {
             ),
             IconButton(
               icon: const Icon(Icons.arrow_forward),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => BlocProvider.value(
-                      value: context.read<HomeCubit>(),
-                      child: const ClassesPage(),
-                    ),
-                  ),
-                );
-              },
+              onPressed: () => context.push(
+                '/classes',
+                extra: context.read<HomeCubit>(),
+              ),
             )
           ],
         ),
@@ -432,17 +419,10 @@ class _ExploreViewState extends State<_ExploreView> {
             ),
             IconButton(
               icon: const Icon(Icons.arrow_forward),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => BlocProvider.value(
-                      value: context.read<HomeCubit>(),
-                      child: const ProgramsPage(),
-                    ),
-                  ),
-                );
-              },
+              onPressed: () => context.push(
+                '/programs',
+                extra: context.read<HomeCubit>(),
+              ),
             )
           ],
         ),
@@ -489,16 +469,12 @@ class _ClassCard extends StatelessWidget {
         int.tryParse(RegExp(r'\d+').firstMatch(subtitle)?.group(0) ?? '') ?? 0;
     return GestureDetector(
       onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => ClassDetailPage(
-              title: title,
-              image: image,
-              videoCount: videoCount, description: '',
-            ),
-          ),
-        );
+        context.push('/class-detail', extra: {
+          'title': title,
+          'image': image,
+          'videoCount': videoCount,
+          'description': '',
+        });
       },
       child: ClipRRect(
         borderRadius: BorderRadius.circular(12),

--- a/lib/features/home/view/programs_page.dart
+++ b/lib/features/home/view/programs_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:saara/widgets/custom_app_bar.dart';
 import '../cubit/home_cubit.dart';
-import 'class_detail_page.dart';
 
 class ProgramsPage extends StatelessWidget {
   const ProgramsPage({super.key});
@@ -23,19 +23,12 @@ class ProgramsPage extends StatelessWidget {
             leading: Image.asset(item.image, width: 60, fit: BoxFit.cover),
             title: Text(item.title),
             subtitle: Text(item.subtitle),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => ClassDetailPage(
-                    title: item.title,
-                    image: item.image,
-                    videoCount: videoCount,
-                    description: '',
-                  ),
-                ),
-              );
-            },
+            onTap: () => context.push('/class-detail', extra: {
+              'title': item.title,
+              'image': item.image,
+              'videoCount': videoCount,
+              'description': '',
+            }),
           );
         },
       ),

--- a/lib/features/video/view/video_page.dart
+++ b/lib/features/video/view/video_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoPage extends StatefulWidget {
@@ -92,7 +93,7 @@ class _VideoPageState extends State<VideoPage> with WidgetsBindingObserver {
               leading: const Icon(Icons.file_download),
               title: const Text('Download'),
               onTap: () {
-                Navigator.pop(ctx);
+                ctx.pop();
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Download tapped')), );
               },
@@ -101,7 +102,7 @@ class _VideoPageState extends State<VideoPage> with WidgetsBindingObserver {
               leading: const Icon(Icons.share),
               title: const Text('Share'),
               onTap: () {
-                Navigator.pop(ctx);
+                ctx.pop();
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Share tapped')), );
               },
@@ -141,7 +142,7 @@ class _VideoPageState extends State<VideoPage> with WidgetsBindingObserver {
                     backgroundColor: Colors.black38,
                     child: IconButton(
                       icon: const Icon(Icons.close, color: Colors.white),
-                      onPressed: () => Navigator.pop(context),
+                      onPressed: () => context.pop(),
                     ),
                   ),
               ),
@@ -276,10 +277,9 @@ class _VideoPageState extends State<VideoPage> with WidgetsBindingObserver {
                               onPressed: () async {
                                 final wasPlaying = _controller.value.isPlaying;
                                 _hideTimer?.cancel();
-                                await Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (_) => FullScreenVideo(controller: _controller),
-                                  ),
+                                await context.push(
+                                  '/video/fullscreen',
+                                  extra: _controller,
                                 );
                                 if (wasPlaying) {
                                   _controller.play();
@@ -556,7 +556,7 @@ class FullScreenVideo extends StatelessWidget {
     return Scaffold(
       backgroundColor: Colors.black,
       body: GestureDetector(
-        onTap: () => Navigator.pop(context),
+        onTap: () => context.pop(),
         child: Center(
           child: AspectRatio(
             aspectRatio:


### PR DESCRIPTION
## Summary
- add GoRouter routes for notifications, classes, programs, class details, and fullscreen video
- replace Navigator calls with context-based go_router navigation across pages
- show bottom sheet and fullscreen video with go_router pop/push helpers

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689474d777bc8331b80233a8a6083e05