### PR TITLE
Revamp classes page with reusable card grid

### DIFF
--- a/lib/features/home/view/classes_page.dart
+++ b/lib/features/home/view/classes_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
 import 'package:saara/widgets/custom_app_bar.dart';
+import 'package:saara/widgets/class_card.dart';
 import '../cubit/home_cubit.dart';
 
 class ClassesPage extends StatelessWidget {
@@ -12,23 +12,25 @@ class ClassesPage extends StatelessWidget {
     final classes = context.watch<HomeCubit>().state.classes;
     return Scaffold(
       appBar: const CustomAppBar(title: 'Classes'),
-      body: ListView.builder(
-        itemCount: classes.length,
-        itemBuilder: (context, index) {
-          final item = classes[index];
-          final videoCount = int.tryParse(RegExp(r'\d+').firstMatch(item.subtitle)?.group(0) ?? '') ?? 0;
-          return ListTile(
-            leading: Image.asset(item.image, width: 60, fit: BoxFit.cover),
-            title: Text(item.title),
-            subtitle: Text(item.subtitle),
-            onTap: () => context.push('/class-detail', extra: {
-              'title': item.title,
-              'image': item.image,
-              'videoCount': videoCount,
-              'description': '',
-            }),
-          );
-        },
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: GridView.builder(
+          itemCount: classes.length,
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2,
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            childAspectRatio: 3 / 2,
+          ),
+          itemBuilder: (context, index) {
+            final item = classes[index];
+            return ClassCard(
+              image: item.image,
+              title: item.title,
+              subtitle: item.subtitle,
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -7,6 +7,7 @@ import 'package:video_player/video_player.dart';
 import 'package:saara/widgets/custom_app_bar.dart';
 import '../cubit/home_cubit.dart';
 import 'classes_page.dart';
+import 'package:saara/widgets/class_card.dart';
 import 'programs_page.dart';
 import '../../settings/view/settings_page.dart';
 import '../../search/view/search_page.dart';
@@ -329,10 +330,13 @@ class _ExploreViewState extends State<_ExploreView> {
                 separatorBuilder: (_, __) => const SizedBox(width: 12),
                 itemBuilder: (context, index) {
                   final item = state.classes[index];
-                  return _ClassCard(
-                    image: item.image,
-                    title: item.title,
-                    subtitle: item.subtitle,
+                  return SizedBox(
+                    width: 240,
+                    child: ClassCard(
+                      image: item.image,
+                      title: item.title,
+                      subtitle: item.subtitle,
+                    ),
                   );
                 },
               );
@@ -452,62 +456,6 @@ class _ExploreViewState extends State<_ExploreView> {
       ],
     ),
   );
-  }
-}
-
-class _ClassCard extends StatelessWidget {
-  final String image, title, subtitle;
-  const _ClassCard({
-    required this.image,
-    required this.title,
-    required this.subtitle,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final videoCount =
-        int.tryParse(RegExp(r'\d+').firstMatch(subtitle)?.group(0) ?? '') ?? 0;
-    return GestureDetector(
-      onTap: () {
-        context.push('/class-detail', extra: {
-          'title': title,
-          'image': image,
-          'videoCount': videoCount,
-          'description': '',
-        });
-      },
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: Stack(
-          children: [
-            Image.asset(image, height: 160, width: 240, fit: BoxFit.cover),
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: Container(
-                color: const Color(0xFFA78BFA).withOpacity(0.9),
-                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        title,
-                        style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                    Text(subtitle,
-                        style: const TextStyle(color: Colors.white70)),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/widgets/class_card.dart
+++ b/lib/widgets/class_card.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ClassCard extends StatelessWidget {
+  final String image;
+  final String title;
+  final String subtitle;
+
+  const ClassCard({
+    super.key,
+    required this.image,
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final videoCount = int.tryParse(
+          RegExp(r'\d+').firstMatch(subtitle)?.group(0) ?? '',
+        ) ??
+        0;
+    return GestureDetector(
+      onTap: () {
+        context.push('/class-detail', extra: {
+          'title': title,
+          'image': image,
+          'videoCount': videoCount,
+          'description': '',
+        });
+      },
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Image.asset(image, fit: BoxFit.cover),
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                color: const Color(0xFFA78BFA).withOpacity(0.9),
+                padding:
+                    const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(color: Colors.white70),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable `ClassCard` widget for consistent class previews
- replace classes list with responsive grid layout
- update home page to use shared `ClassCard`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689478bd5f7c83319abf28c4cc577cd5