### PR TITLE
Make program cards open video and remove welcome snackbar

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -165,10 +165,6 @@ class App extends StatelessWidget {
             return BlocListener<AuthBloc, AuthState>(
               listener: (context, state) {
                 if (state.status == AuthStatus.authenticated) {
-                  final name = state.user?.name ?? state.user?.email ?? 'User';
-                  _messengerKey.currentState?.showSnackBar(
-                    SnackBar(content: Text('Welcome $name')),
-                  );
                   router.go('/');
                 } else if (state.error != null) {
                   _messengerKey.currentState?.showSnackBar(

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -445,6 +445,7 @@ class _ExploreViewState extends State<_ExploreView> {
                     image: item.image,
                     title: item.title,
                     subtitle: item.subtitle,
+                    onTap: () => context.push('/video'),
                   );
                 },
               );
@@ -493,10 +494,12 @@ class _FeatureCard extends StatelessWidget {
 
 class _ProgramCard extends StatelessWidget {
   final String image, title, subtitle;
+  final VoidCallback? onTap;
   const _ProgramCard({
     required this.image,
     required this.title,
     required this.subtitle,
+    this.onTap,
   });
 
   @override
@@ -507,36 +510,39 @@ class _ProgramCard extends StatelessWidget {
         elevation: 3,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         clipBehavior: Clip.antiAlias,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Image.asset(
-                image,
-                width: double.infinity,
-                fit: BoxFit.cover,
+        child: InkWell(
+          onTap: onTap,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Image.asset(
+                  image,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: const TextStyle(
-                        fontWeight: FontWeight.bold, fontSize: 16),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    subtitle,
-                    style:
-                        const TextStyle(color: Colors.black54, fontSize: 14),
-                  ),
-                ],
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.bold, fontSize: 16),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle,
+                      style:
+                          const TextStyle(color: Colors.black54, fontSize: 14),
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Navigate to the video page when a program card is tapped on the home screen
- Drop the welcome SnackBar that appeared after authentication

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689482b09a3c833196329bd8f68aa059