### PR TITLE
Connect search to video playback and refresh notifications

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -82,7 +82,13 @@ class App extends StatelessWidget {
                 ),
                 GoRoute(
                   path: '/video',
-                  builder: (context, state) => const VideoPage(),
+                  builder: (context, state) {
+                    final data = state.extra as Map<String, String>?;
+                    return VideoPage(
+                      title: data?['title'],
+                      url: data?['url'],
+                    );
+                  },
                 ),
                 GoRoute(
                   path: '/video/fullscreen',

--- a/lib/features/notifications/view/notification_page.dart
+++ b/lib/features/notifications/view/notification_page.dart
@@ -12,18 +12,44 @@ class NotificationPage extends StatelessWidget {
       create: (_) => NotificationCubit(),
       child: Scaffold(
         appBar: const CustomAppBar(title: 'Notifications'),
-        body: BlocBuilder<NotificationCubit, List<String>>(
-          builder: (context, notifications) {
-            if (notifications.isEmpty) {
-              return const Center(child: Text('No notifications'));
-            }
-            return ListView.builder(
-              itemCount: notifications.length,
-              itemBuilder: (context, index) {
-                return ListTile(title: Text(notifications[index]));
-              },
-            );
-          },
+        body: Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [Color(0xFFA78BFA), Color(0xFF6C63FF)],
+            ),
+          ),
+          child: BlocBuilder<NotificationCubit, List<String>>(
+            builder: (context, notifications) {
+              if (notifications.isEmpty) {
+                return const Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.notifications_off,
+                          size: 64, color: Colors.white70),
+                      SizedBox(height: 16),
+                      Text('No notifications',
+                          style: TextStyle(color: Colors.white70)),
+                    ],
+                  ),
+                );
+              }
+              return ListView.builder(
+                padding: const EdgeInsets.all(16),
+                itemCount: notifications.length,
+                itemBuilder: (context, index) {
+                  return Card(
+                    child: ListTile(
+                      leading: const Icon(Icons.notifications),
+                      title: Text(notifications[index]),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/features/search/view/search_page.dart
+++ b/lib/features/search/view/search_page.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 /// A creative search experience with animated results and quick suggestions.
 class SearchPage extends StatefulWidget {
@@ -23,6 +24,23 @@ class _SearchPageState extends State<SearchPage> with SingleTickerProviderStateM
     'Yoga Flow Series Intro',
     'Summer Challenge Finale',
   ];
+
+  /// Demo mapping of titles to video URLs. Normally this would come from
+  /// an API or database.
+  final Map<String, String> _videoUrls = const {
+    'Beginner Challenge Day 1':
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    'Beginner Challenge Day 2':
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    'ABS Challenge Warmup':
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    'Daily Flow Session':
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    'Yoga Flow Series Intro':
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    'Summer Challenge Finale':
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+  };
 
   List<String> _filtered = const [];
 
@@ -135,12 +153,14 @@ class _SearchPageState extends State<SearchPage> with SingleTickerProviderStateM
                         itemBuilder: (context, index) {
                           final title = _filtered[index];
                           return ListTile(
-                            title: Text(title, style: const TextStyle(color: Colors.white)),
-                            trailing: const Icon(Icons.play_arrow, color: Colors.white),
+                            title: Text(title,
+                                style: const TextStyle(color: Colors.white)),
+                            trailing:
+                                const Icon(Icons.play_arrow, color: Colors.white),
                             onTap: () {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text('Selected "$title"')),
-                              );
+                              final url = _videoUrls[title];
+                              context.push('/video',
+                                  extra: {'title': title, 'url': url});
                             },
                           );
                         },

--- a/lib/features/video/view/video_page.dart
+++ b/lib/features/video/view/video_page.dart
@@ -6,7 +6,10 @@ import 'package:go_router/go_router.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoPage extends StatefulWidget {
-  const VideoPage({super.key});
+  const VideoPage({super.key, this.title, this.url});
+
+  final String? title;
+  final String? url;
 
   @override
   State<VideoPage> createState() => _VideoPageState();
@@ -26,7 +29,8 @@ class _VideoPageState extends State<VideoPage> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
     _pageController = PageController();
     _controller = VideoPlayerController.network(
-      'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+      widget.url ??
+          'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
     )
       ..initialize().then((_) {
         setState(() {});
@@ -482,8 +486,21 @@ class _VideoPageState extends State<VideoPage> with WidgetsBindingObserver {
         child: Scaffold(
           backgroundColor: Colors.black,
           body: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildHeader(),
+              if (widget.title != null)
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(
+                    widget.title!,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
               Expanded(
                 child: Container(
                   color: Colors.white,


### PR DESCRIPTION
## Summary
- Link search results to the video screen with mapped URLs so tapping an item starts playback.
- Allow VideoPage to accept a title and URL, automatically playing and showing the selected video.
- Restyle notifications with gradient background and card-based list items for a more engaging look.

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689483ddd5588331a4403d629934e48c