### PR TITLE
style: enhance settings page UI

### DIFF
--- a/lib/features/settings/view/settings_page.dart
+++ b/lib/features/settings/view/settings_page.dart
@@ -20,23 +20,64 @@ class _SettingsPageState extends State<SettingsPage> {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        SwitchListTile(
+        _SettingsTile(
+          icon: Icons.notifications_active_outlined,
+          title: 'Enable notifications',
+          subtitle: 'Stay up to date with new classes and events',
           value: _notificationsEnabled,
-          activeColor: primaryPurple,
-          title: const Text('Enable notifications'),
           onChanged: (value) {
             setState(() => _notificationsEnabled = value);
           },
         ),
-        SwitchListTile(
+        _SettingsTile(
+          icon: context.watch<ThemeCubit>().state == ThemeMode.dark
+              ? Icons.dark_mode_outlined
+              : Icons.light_mode_outlined,
+          title: 'Dark mode',
+          subtitle: 'Reduce eye strain with a darker theme',
           value: context.watch<ThemeCubit>().state == ThemeMode.dark,
-          activeColor: primaryPurple,
-          title: const Text('Dark mode'),
           onChanged: (value) {
             context.read<ThemeCubit>().toggle(value);
           },
         ),
       ],
+    );
+  }
+}
+
+class _SettingsTile extends StatelessWidget {
+  const _SettingsTile({
+    required this.icon,
+    required this.title,
+    this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    const primaryPurple = Color(0xFFA78BFA);
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: SwitchListTile.adaptive(
+        secondary: Icon(icon, color: primaryPurple),
+        value: value,
+        activeColor: primaryPurple,
+        title: Text(
+          title,
+          style: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+        subtitle: subtitle != null ? Text(subtitle!) : null,
+        onChanged: onChanged,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add reusable SettingsTile with icons and subtitles
- redesign settings page using card tiles for notifications and dark mode

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894850dcd848331bcbb2a2a0bcbf580