### PR TITLE
Fix video search results navigation

### DIFF
--- a/lib/features/search/view/search_page.dart
+++ b/lib/features/search/view/search_page.dart
@@ -159,8 +159,12 @@ class _SearchPageState extends State<SearchPage> with SingleTickerProviderStateM
                                 const Icon(Icons.play_arrow, color: Colors.white),
                             onTap: () {
                               final url = _videoUrls[title];
-                              context.push('/video',
-                                  extra: {'title': title, 'url': url});
+                              if (url != null) {
+                                context.push(
+                                  '/video',
+                                  extra: {'title': title, 'url': url},
+                                );
+                              }
                             },
                           );
                         },


### PR DESCRIPTION
## Summary
- ensure search results only navigate to video page when a URL is present

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689485d8de9c8331bb769f2f8aab3bcc